### PR TITLE
Add lazyFoldLeft

### DIFF
--- a/src/main/scala/scala/collection/decorators/IterableDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/IterableDecorator.scala
@@ -19,6 +19,21 @@ class IterableDecorator[C, I <: IsIterable[C]](coll: C)(implicit val it: I) {
   def foldSomeLeft[B](z: B)(op: (B, it.A) => Option[B]): B =
     it(coll).iterator.foldSomeLeft(z)(op)
 
+  /** Lazy left to right fold. Like `foldLeft` but the combination function `op` is
+    * non-strict in its second parameter. If `op(b, a)` chooses not to evaluate `a` and
+    * returns `b`, this terminates the traversal early.
+    *
+    * @param z  the start value
+    * @param op the binary operator
+    * @tparam B the result type of the binary operator
+    * @return   the result of inserting `op` between consecutive elements of the
+    *           collection, going left to right with the start value `z` on the left,
+    *           and stopping when all the elements have been traversed or earlier if
+    *           `op(b, a)` choose not to evaluate `a` and returns `b`
+    */
+  def lazyFoldLeft[B](z: B)(op: (B, => it.A) => B): B =
+    it(coll).iterator.lazyFoldLeft(z)(op)
+
   /**
     * Right to left fold that can be interrupted before traversing the whole collection.
     * @param z the start value

--- a/src/main/scala/scala/collection/decorators/IteratorDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/IteratorDecorator.scala
@@ -52,6 +52,20 @@ class IteratorDecorator[A](val `this`: Iterator[A]) extends AnyVal {
     result
   }
 
+  def lazyFoldLeft[B](z: B)(op: (B, => A) => B): B = {
+    var result = z
+    var finished = false
+    while (`this`.hasNext && !finished) {
+      var nextEvaluated = false
+      val elem = `this`.next()
+      def getNext = { nextEvaluated = true; elem }
+      val acc = op(result, getNext)
+      finished = !nextEvaluated && acc == result
+      result = acc
+    }
+    result
+  }
+
   def lazyFoldRight[B](z: B)(op: A => Either[B, B => B]): B = {
 
     def chainEval(x: B, fs: immutable.List[B => B]): B =

--- a/src/test/scala/scala/collection/decorators/IterableDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/IterableDecoratorTest.scala
@@ -17,6 +17,24 @@ class IterableDecoratorTest {
       Assert.assertEquals(10, List[Int]().foldSomeLeft(10)((x, y) => Some(x + y)))
     }
 
+  @Test
+  def lazyFoldLeftIsStackSafe(): Unit = {
+    val bigList = List.range(1, 50000)
+    def sum(as: Iterable[Int]): Int =
+      as.lazyFoldLeft(0)(_ + _)
+
+    Assert.assertEquals(sum(bigList), 1249975000)
+  }
+
+  @Test
+  def lazyFoldLeftIsLazy(): Unit = {
+    val nats = LazyList.from(0)
+    def exists[A](as: Iterable[A])(f: A => Boolean): Boolean =
+      as.lazyFoldLeft(false)(_ || f(_))
+    
+    Assert.assertTrue(exists(nats)(_ > 100000))
+  }
+
   @Test def lazyFoldRightIsLazy(): Unit = {
     val xs = LazyList.from(0)
     def chooseOne(x: Int): Either[Int, Int => Int]= if (x < (1 << 16)) Right(identity) else Left(x)


### PR DESCRIPTION
This PR adds a new `lazyFoldLeft` implicit enrichment method to Scala standard collections as discussed [here](https://contributors.scala-lang.org/t/proposal-for-lazyfoldleft/3163/1). `lazyFoldLeft` is like `foldLeft` but the combination function `op` is non-strict in its second parameter. If `op(b, a)` chooses not to evaluate `a` and returns `b`, this terminates the traversal early.

This method addresses a tension that currently exists with using folds in Scala. Lazy right folds are preferable in many ways as a building block for specific folds because they support efficient implementation of methods like `exists` that allow early termination. They also allow traversals of infinite collections. However, right folds are not tail recursive and thus are not stack safe for large collections, a property we usually want to guarantee.

This problem has been addressed in various ways including variations of folds that allow the caller to explicitly signal termination (e.g. `foldLeftSome` or `lazyFoldRight` in this library) or evaluation of the right fold in the context of a stack safe monad (e.g. `lazyFoldRight` in Cats with `Eval`). These solutions are less than ideal for two reasons.

First, they can require more work from the caller to explicitly specify early termination conditions when it should be implied by the operation itself. For example, when implementing `exists` with `foldLeftSome` we could use `None` to explicitly signal termination.

```
def exists[A](as: Iterable[A])(f: A => Boolean): Boolean =
  as.foldLeftSome(false)((b, a) => if (b) None else Some(f(a)))
```

But the early terminating nature of the fold is really inherent in the `||` operator, which can be seen much more clearly without the `Option`.

```
def exists[A](as: Iterable[A])(f: A => Boolean): Boolean =
  lazyFoldLeft(as)(false)(_ || f(_))
```

Second, these solutions require some additional boxing, either in terms of `Option`, `Either`, or `Eval` that negatively impacts performance and reduces the practical utility of these higher order functions in implementing more specific collection operations.

This implementation of `lazyFoldLeft` has a couple of attractive properties.

In terms of soundness, we can show that for any pure function `f: (B, => A) => B`, if `as.foldLeft(z)(f)` terminates, then `as.lazyFoldLeft(z)(f)` terminates with the same value. The argument is that `lazyFoldLeft` only terminates early if `op(b, a)` chooses not to evaluate `a` and returns `b`. If when traversing a given element, `f` did not evaluate `a`, then for the given `b`, `f` is effectively a function of type `B => B`. But the second termination condition is that the `op(b, a)` returns `b`. So in that case calling `f` again with the next element in the traversal will also not evaluate `a` and will also return `b`, assuming that `f` is a pure function. By induction we can apply the same logic to every remaining element and safely terminate the traversal early.

My benchmarking also indicates that the performance cost of using a lazy left fold instead of a strict one is relatively low. Essentially the only additional work in traversing each element is setting and getting a boolean value.

So it seems like this could be a very useful method allowing us to implement a wide variety of methods in a relatively efficient way. I added some basic tests but didn't see the infrastructure for property-based testing or benchmarks. I'm happy to add those if that is helpful.