### PR TITLE
Remove an unresolvable Scaladoc macro call

### DIFF
--- a/src/main/scala/scala/collection/decorators/SeqDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/SeqDecorator.scala
@@ -48,7 +48,7 @@ class SeqDecorator[C, S <: IsSeq[C]](coll: C)(implicit val seq: S) {
     *
     * @param elem        the element to replace
     * @param replacement the replacement element
-    * @tparam B          the element type of the returned $coll.
+    * @tparam B          the element type of the returned collection.
     * @return            a new sequence consisting of all elements of this sequence
     *                    except that all occurrences of `elem` are replaced by
     *                    `replacement`


### PR DESCRIPTION
This caused a warning during publishing:

    [warn] /.../scala-collection-contrib/src/main/scala/scala/collection/decorators/SeqDecorator.scala:51:60: Variable coll undefined in comment for method replaced in class SeqDecorator
    [warn]     * @tparam B          the element type of the returned $coll.
    [warn]                                                            ^
    [warn] one warning found
