### PR TITLE
Run the CI only on the right module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ env:
     - secure: "ggXFZBlzV5ek/rBaE9lrEZlAIfUrv4XDJ4OrP8daMrJxmwkXtoSbcB3z4VgqqWKzAzW89CcU1IiojzDbe/het3xEX4qxdz5Wt05/E+WOgbek528kelwMxq12XRe6xaCVfG+y8OISPgq1q3vKoO/xYGVbK3D6hSD+cjojEXyPpjAfrVSUof06aNPFPQeLX9exgu9zrxkJJm01PbTh19vQk4Ojc++oEmpF7HLD1CF1m7AlW0U2Rba+syivpj9Ray3Z9vu0TnFL06r4TiwZruwcXTLrWUqumFI0r5mhaY6SNH7bqttu+3RPIOdkUGxIeGlkDi3xopt7r2aEkhOKvjRXapW0e/CWmUo1J+NnlIumxrldi4n0iiJGVEvY4Krx/HGZe0wCVTh4vDNOllTGdFmkkxN6WoaHALgj3QNM3XLjvvUu3VcT+QNtsVIvgUDesrtos8zCKczzdhL/d4BMiIg7SFfA33S3vx8BeczLBqddrx+yLSPzfheKrHW7g76EAEyN26vE2/2/GRlMOlG8Lmu8rXBfIPsK9T/ztfE1CxaTW5EsMSrxO2+O/bvAa6DY0R79KkHf7LDI+azzP2NwYx8anM9WlMTp4EbawI/KGZRilWYtJ3Q3y5EQERsrP71W35dKqiBFMPdspS+lTS9hGtso08n7cR2MwTbRjoXVRcWfJ/I="
   matrix:
     # The empty SCALAJS_VERSION will only compile for the JVM
-    - SCALAJS_VERSION=         ADOPTOPENJDK=8
-    - SCALAJS_VERSION=0.6.28   ADOPTOPENJDK=8
-    - SCALAJS_VERSION=1.0.0-M8 ADOPTOPENJDK=8
-    - SCALAJS_VERSION=         ADOPTOPENJDK=11
+    - SCALAJS_VERSION=         ADOPTOPENJDK=8  MODULE=scala-collection-contrib
+    - SCALAJS_VERSION=0.6.28   ADOPTOPENJDK=8  MODULE=scala-collection-contribJS
+    - SCALAJS_VERSION=1.0.0-M8 ADOPTOPENJDK=8  MODULE=scala-collection-contribJS
+    - SCALAJS_VERSION=         ADOPTOPENJDK=11 MODULE=scala-collection-contrib
 
 before_install:
   # adding $HOME/.sdkman to cache would create an empty directory, which interferes with the initial installation
@@ -40,6 +40,8 @@ before_cache:
 cache:
   directories:
   - $HOME/.ivy2/cache
+  - $HOME/.coursier
+  - $HOME/.sbt/1.0
   - $HOME/.sbt/boot
   - $HOME/.sbt/launchers
   - $HOME/.sdkman

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -33,7 +33,7 @@ if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
     currentJvmVer=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^1\.//' | sed 's/[^0-9].*//')
     echo "Releasing $tagVer with Scala $TRAVIS_SCALA_VERSION on Java version $currentJvmVer."
 
-    publishTask="publishSigned"
+    publishTask="$MODULE/publishSigned"
 
     cat admin/gpg.sbt >> project/plugins.sbt
     cp admin/publish-settings.sbt .
@@ -45,4 +45,4 @@ if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
   fi
 fi
 
-sbt "++$TRAVIS_SCALA_VERSION" "$publishVersion" "clean" "test" "publishLocal" "$publishTask"
+sbt "++$TRAVIS_SCALA_VERSION" "$publishVersion" "$MODULE/clean" "$MODULE/test" "$publishTask"


### PR DESCRIPTION
We previously run the CI tasks on the root module, which aggregates
both the JS and JVM modules. This resulted in wasting CPU and
duplicating releases on Sonatype (see https://github.com/scala/scala-collection-contrib/pull/43#issuecomment-527109694)