### PR TITLE
BitSet shift left - skip zero words

### DIFF
--- a/src/main/scala/scala/collection/decorators/BitSetDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/BitSetDecorator.scala
@@ -8,7 +8,7 @@ class BitSetDecorator[+C <: BitSet with BitSetOps[C]](protected val bs: C) {
   import BitSetOps._
 
   /**
-    * Bitwise left shift of this BitSet by given the shift distance.
+    * Bitwise left shift of this BitSet by the given shift distance.
     * The shift distance may be negative, in which case this method performs a right shift.
     * @param shiftBy shift distance, in bits
     * @return a new BitSet whose value is a bitwise shift left of this BitSet by given shift distance (`shiftBy`)

--- a/src/test/scala/scala/collection/decorators/BitSetDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/BitSetDecoratorTest.scala
@@ -37,6 +37,13 @@ class BitSetDecoratorTest {
   }
 
   @Test
+  def skipZeroWordsOnShiftLeft(): Unit = {
+    val result = BitSet(5 * 64 - 1) << 64
+    assertEquals(BitSet(6 * 64 - 1), result)
+    assertEquals(6, result.nwords)
+  }
+
+  @Test
   def shiftEmptyRight(): Unit = {
     for (shiftBy <- 0 to 128) {
       assertSame(empty, empty >> shiftBy)


### PR DESCRIPTION
I've realized that Scala `BitSet`s might have (and usually they do have) some zero words above the highest set bit, which I guess contradicts the statement in the documentation:

> The memory footprint of a bitset is determined by the largest number stored in it.

My initial implementation of `<<` kept those zero words and pushed them to the left. As a result, there was an edge case with large BitSets, where those zero words would not fit in the size limit. 

For example, `BitSet(Int.MaxValue - 64) << 64` would throw an `IllegalArgumentException` while it should result in `BitSet(Int.MaxValue)`.

I am submitting a fix which addresses the issue by skipping any zero words existing above the highest set bit. In many cases, this also reduces the amount of memory allocated to the resulting `BitSet`.

@julienrf 