### PR TITLE
Iterator.takeUntilException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ before_install:
   # adding $HOME/.sdkman to cache would create an empty directory, which interferes with the initial installation
   - "[[ -d $HOME/.sdkman/bin ]] || rm -rf $HOME/.sdkman/"
   - curl -sL https://get.sdkman.io | bash
-  - echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
+  - (echo sdkman_auto_answer=true; echo sdkman_auto_selfupdate=true) > $HOME/.sdkman/etc/config
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
-  - sdk update
 
 install:
   - sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
   # adding $HOME/.sdkman to cache would create an empty directory, which interferes with the initial installation
   - "[[ -d $HOME/.sdkman/bin ]] || rm -rf $HOME/.sdkman/"
   - curl -sL https://get.sdkman.io | bash
-  - sdk selfupdate force
   - echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - sdk selfupdate force
 
 install:
   - sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - curl -sL https://get.sdkman.io | bash
   - echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
-  - sdk selfupdate force
+  - sdk update
 
 install:
   - sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   # adding $HOME/.sdkman to cache would create an empty directory, which interferes with the initial installation
   - "[[ -d $HOME/.sdkman/bin ]] || rm -rf $HOME/.sdkman/"
   - curl -sL https://get.sdkman.io | bash
+  - sdk selfupdate force
   - echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
 

--- a/src/main/scala/scala/collection/decorators/IteratorDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/IteratorDecorator.scala
@@ -235,24 +235,7 @@ class IteratorDecorator[A](val `this`: Iterator[A]) extends AnyVal {
     * @note   Reuse: $consumesAndProducesIterator
     */
   def takeUntilException: Iterator[A] = {
-    new AbstractIterator[A] {
-      private val wrapped = `this`.buffered
-
-      override def hasNext: Boolean = {
-        try {
-          val n = wrapped.hasNext
-          // By already invoking `head` (and therefore also `next` on `this`),
-          // we are sure that `wrapped.next` will not throw when it is used from
-          // `next`.
-          if (n) wrapped.head
-          n
-        } catch {
-          case NonFatal(t) => false
-        }
-      }
-
-      override def next(): A = wrapped.next
-    }
+    takeUntilException(_ => ())
   }
 
   /** Gives elements from the source iterator until the source iterator ends or throws an exception.

--- a/src/main/scala/scala/collection/decorators/IteratorDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/IteratorDecorator.scala
@@ -241,8 +241,8 @@ class IteratorDecorator[A](val `this`: Iterator[A]) extends AnyVal {
 
   /** Gives elements from the source iterator until the source iterator ends or throws a NonFatal exception.
     *
-    * @param  exceptionCaught a callback invoked from `hasNext` when the source iterator throws aNonFatal exception
-    * @return an iterator that takes items until the wrapped iterator ends or throws aNonFatal exception
+    * @param  exceptionCaught a callback invoked from `hasNext` when the source iterator throws a NonFatal exception
+    * @return an iterator that takes items until the wrapped iterator ends or throws a NonFatal exception
     * @see    scala.util.control.NonFatal
     * @note   Reuse: $consumesAndProducesIterator
     */

--- a/src/main/scala/scala/collection/decorators/IteratorDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/IteratorDecorator.scala
@@ -229,19 +229,21 @@ class IteratorDecorator[A](val `this`: Iterator[A]) extends AnyVal {
       }
     }
 
-  /** Gives elements from the source iterator until the source iterator ends or throws an exception.
+  /** Gives elements from the source iterator until the source iterator ends or throws a NonFatal exception.
     *
-    * @return an iterator that takes items until the source iterator ends or throws an exception
+    * @return an iterator that takes items until the source iterator ends or throws a NonFatal exception
+    * @see    scala.util.control.NonFatal
     * @note   Reuse: $consumesAndProducesIterator
     */
   def takeUntilException: Iterator[A] = {
     takeUntilException(_ => ())
   }
 
-  /** Gives elements from the source iterator until the source iterator ends or throws an exception.
+  /** Gives elements from the source iterator until the source iterator ends or throws a NonFatal exception.
     *
-    * @param  exceptionCaught a callback invoked from `hasNext` when the source iterator throws an exception
-    * @return an iterator that takes items until the wrapped iterator ends or throws an exception
+    * @param  exceptionCaught a callback invoked from `hasNext` when the source iterator throws aNonFatal exception
+    * @return an iterator that takes items until the wrapped iterator ends or throws aNonFatal exception
+    * @see    scala.util.control.NonFatal
     * @note   Reuse: $consumesAndProducesIterator
     */
   def takeUntilException(exceptionCaught: Throwable => Unit): Iterator[A] = {

--- a/src/test/scala/scala/collection/decorators/IteratorDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/IteratorDecoratorTest.scala
@@ -117,4 +117,67 @@ class IteratorDecoratorTest {
       Iterator((1,1), (1,2), (2,3), (1,4)).splitBy(_._1).toSeq
     )
   }
+
+  @Test
+  def takeUntilExceptionShouldWrapAnyNonThrowingIterator(): Unit = {
+    Assert.assertEquals(Seq(1, 2, 3, 4, 5), Iterator(1, 2, 3, 4, 5).takeUntilException.toSeq)
+    Assert.assertEquals(Seq(1, 2, 3, 4, 5), Iterator(1, 2, 3, 4, 5).takeUntilException(_ => ()).toSeq)
+    Assert.assertEquals(Seq.empty, Iterator.empty.takeUntilException.toSeq)
+    Assert.assertEquals(Seq.empty, Iterator.empty.takeUntilException(_ => ()).toSeq)
+    // Works with infinite iterators:
+    Assert.assertEquals(Seq(1, 2, 3, 4, 5), Iterator.from(1).takeUntilException.take(5).toSeq)
+    Assert.assertEquals(Seq(1, 2, 3, 4, 5), Iterator.from(1).takeUntilException(_ => ()).take(5).toSeq)
+  }
+
+  @Test
+  def takeUntilExceptionShouldTakeTillAnExceptionFromHasNext(): Unit = {
+    val toThrow = new RuntimeException("~expected exception~")
+    def brokenIterator: Iterator[Int] = new AbstractIterator[Int] {
+      private var previousPosition = 0
+
+      override def hasNext: Boolean = {
+        if (previousPosition == 3) {
+          throw toThrow
+        } else {
+          true
+        }
+      }
+
+      override def next(): Int = {
+        previousPosition += 1
+        previousPosition
+      }
+    }
+
+    Assert.assertEquals(Seq(1, 2, 3), brokenIterator.takeUntilException.toSeq)
+
+    var caught: Throwable = null
+    Assert.assertEquals(Seq(1, 2, 3), brokenIterator.takeUntilException(caught = _).toSeq)
+    Assert.assertSame(toThrow, caught)
+  }
+
+  @Test
+  def takeUntilExceptionShouldTakeTillAnExceptionFromNext(): Unit = {
+    val toThrow = new RuntimeException("~expected exception~")
+    def brokenIterator: Iterator[Int] = new AbstractIterator[Int] {
+      private var previousPosition = 0
+
+      override def hasNext: Boolean = true
+
+      override def next(): Int = {
+        if (previousPosition == 3) {
+          throw toThrow
+        } else {
+          previousPosition += 1
+          previousPosition
+        }
+      }
+    }
+
+    Assert.assertEquals(Seq(1, 2, 3), brokenIterator.takeUntilException.toSeq)
+
+    var caught: Throwable = null
+    Assert.assertEquals(Seq(1, 2, 3), brokenIterator.takeUntilException(caught = _).toSeq)
+    Assert.assertSame(toThrow, caught)
+  }
 }


### PR DESCRIPTION
This introduces `Iterator.takeUntilException`, a method that can be useful in situations where you want to get as much out of an iterator as possible. For example, I used it to read records from a corrupted Avro file.