### PR TITLE
Fix ArrayIndexOutOfBoundsException in mutable.BitSet.<<=

### DIFF
--- a/src/test/scala/scala/collection/decorators/MutableBitSetDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/MutableBitSetDecoratorTest.scala
@@ -2,11 +2,12 @@ package scala.collection.decorators
 
 import org.junit.{Assert, Test}
 
+import scala.collection.BitSetOps
 import scala.collection.mutable.BitSet
 
 class MutableBitSetDecoratorTest {
 
-  import Assert.{assertEquals, assertSame}
+  import Assert.{assertEquals, assertSame, assertTrue}
   import BitSet.empty
 
   @Test
@@ -102,6 +103,14 @@ class MutableBitSetDecoratorTest {
       bs >>= shiftBy
       assertEquals(expected, bs)
     }
+  }
+
+  @Test
+  def shiftLeftTwoEmptyWords(): Unit = {
+    val twoWords = BitSet(BitSetOps.WordLength + 1)
+    twoWords ^= twoWords
+    twoWords <<= 1
+    assertTrue(twoWords.isEmpty)
   }
 
 }


### PR DESCRIPTION
Fix `ArrayIndexOutOfBoundsException` that is thrown by `<<=` operation on `mutable.BitSet` consisting of more than one empty word.
Such `BitSet` is possible in practice, even though it seems to contradict the invariant prescribed in the documentation ("The memory footprint of a bitset is determined by the largest number stored in it."). See the added test case for an example.