### PR TITLE
standardize build.sbt and build.sh

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,13 @@
-import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
-
-// With CrossType.Pure, the root project also picks up the sources in `src`
-Compile/sources := Nil
-Test/sources := Nil
+lazy val root = project.in(file("."))
+  .aggregate(collectionContrib.jvm, collectionContrib.js)
+  .settings(
+    publish / skip := true,
+    // With CrossType.Pure, the root project also picks up the sources in `src`
+    Compile / unmanagedSourceDirectories := Nil,
+    Test    / unmanagedSourceDirectories := Nil,
+  )
 
 lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform)
-  .withoutSuffixFor(JVMPlatform)
   .crossType(CrossType.Pure)
   .in(file("."))
   .settings(ScalaModulePlugin.scalaModuleSettings)
@@ -16,12 +18,10 @@ lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform)
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a"),
     parallelExecution in Test := false,  // why?
     libraryDependencies ++= Seq(
-      "junit"            % "junit"           % "4.13.1"   % Test,
+      "junit"            % "junit"           % "4.13.1" % Test,
       "com.novocode"     % "junit-interface" % "0.11"   % Test,
-      "org.openjdk.jol"  % "jol-core"        % "0.14"    % Test
+      "org.openjdk.jol"  % "jol-core"        % "0.14"   % Test
     ),
-    // https://github.com/sbt/sbt/issues/5043
-    useCoursier := false
   )
   .jvmSettings(
     scalaModuleMimaPreviousVersion := Some("0.1.0")
@@ -31,3 +31,6 @@ lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform)
     // Scala.js cannot run forked tests
     fork in Test := false
   )
+
+lazy val collectionContribJVM = collectionContrib.jvm
+lazy val collectionContribJS  = collectionContrib.js

--- a/build.sh
+++ b/build.sh
@@ -10,11 +10,13 @@ set -e
 # sbt-dynver sets the version number from the tag
 # sbt-travisci sets the Scala version from the travis job matrix
 
-# When a new binary incompatible Scala version becomes available, a previously released version
-# can be released using that new Scala version by creating a new tag containing the Scala version
-# after a hash, e.g., v1.2.3#2.13.0-M3.
+# To back-publish an existing release for a new Scala / Scala.js / Scala Native version:
+# - check out the tag for the version that needs to be published
+# - change `.travis.yml` to adjust the version numbers and trim down the build matrix as necessary
+# - commit the changes and tag this new revision with an arbitrary suffix after a hash, e.g.,
+#   `v1.2.3#dotty-0.27` (the suffix is ignored, the version will be `1.2.3`)
 
-# For normal tags that are cross-built, we release on JDK 8 for Scala 2.x
+# We release on JDK 8 (for Scala 2.x and Dotty 0.x)
 isReleaseJob() {
   if [[ "$ADOPTOPENJDK" == "8" ]]; then
     true
@@ -23,49 +25,30 @@ isReleaseJob() {
   fi
 }
 
-# For tags that define a Scala version, we pick the jobs of one Scala version (2.13.x) to do the releases
-isTagScalaReleaseJob() {
-  if [[ "$ADOPTOPENJDK" == "8" && "$TRAVIS_SCALA_VERSION" =~ ^2\.13\.[0-9]+$ ]]; then
-    true
-  else
-    false
-  fi
-}
-
-if [[ "$SCALAJS_VERSION" != "" ]]; then
-  projectPrefix="collectionContribJS"
+if [[ "$SCALAJS_VERSION" == "" ]]; then
+  projectPrefix="collectionContribJVM/"
 else
-  projectPrefix="collectionContrib"
+  projectPrefix="collectionContribJS/"
 fi
 
 verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
-tagPat="^v$verPat(#$verPat)?$"
+tagPat="^v$verPat(#.*)?$"
 
 if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
   releaseTask="ci-release"
-  tagScalaVer=$(echo $TRAVIS_TAG | sed s/[^#]*// | sed s/^#//)
-  if [[ "$tagScalaVer" == "" ]]; then
-    if ! isReleaseJob; then
-      echo "Not releasing on Java $ADOPTOPENJDK with Scala $TRAVIS_SCALA_VERSION"
-      exit 0
-    fi
-  else
-    if isTagScalaReleaseJob; then
-      setTagScalaVersion='set every scalaVersion := "'$tagScalaVer'"'
-    else
-      echo "The releases for Scala $tagScalaVer are built by other jobs in the travis job matrix"
-      exit 0
-    fi
+  if ! isReleaseJob; then
+    echo "Not releasing on Java $ADOPTOPENJDK with Scala $TRAVIS_SCALA_VERSION"
+    exit 0
   fi
 fi
 
 # default is +publishSigned; we cross-build with travis jobs, not sbt's crossScalaVersions
-export CI_RELEASE="$projectPrefix/publishSigned"
-export CI_SNAPSHOT_RELEASE="$projectPrefix/publish"
+export CI_RELEASE="${projectPrefix}publishSigned"
+export CI_SNAPSHOT_RELEASE="${projectPrefix}publish"
 
 # default is sonatypeBundleRelease, which closes and releases the staging repo
 # see https://github.com/xerial/sbt-sonatype#commands
 # for now, until we're confident in the new release scripts, just close the staging repo.
 export CI_SONATYPE_RELEASE="; sonatypePrepare; sonatypeBundleUpload; sonatypeClose"
 
-sbt "$setTagScalaVersion" clean $projectPrefix/test $projectPrefix/publishLocal $releaseTask
+sbt clean ${projectPrefix}test ${projectPrefix}publishLocal $releaseTask


### PR DESCRIPTION
adopt tweaks from scala-xml (our "standard" module) and scala-library-next (the most-recently-set-up one) here

the main change is to adopt the new build.sh style where we get rid of the special tag stuff for back-publishing

I've also chosen to get rid of `.withoutSuffixFor(JVMPlatform)` because I don't like it, IMO it makes it too easy to confuse the root project with the JVM project