### PR TITLE
New circular Seq operations: rotateRight, rotateLeft, startAt

### DIFF
--- a/src/main/scala/scala/collection/decorators/SeqDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/SeqDecorator.scala
@@ -76,7 +76,7 @@ class SeqDecorator[C, S <: IsSeq[C]](coll: C)(implicit val seq: S) {
    * @return a new collection consisting of all elements of this collection
    *         circularly rotated by `step` places to the right.
    * @example {{{
-   *      List(1, 2, 3, 4, 5).rotateRight(1) => List(2, 3, 4, 5, 1)
+   *      List(1, 2, 3, 4, 5).rotateRight(1) => List(5, 1, 2, 3, 4)
    * }}}
    */
   def rotateRight[B >: seq.A, That](step: Int)(implicit bf: BuildFrom[C, B, That]): That =
@@ -94,7 +94,7 @@ class SeqDecorator[C, S <: IsSeq[C]](coll: C)(implicit val seq: S) {
    * @return a new collection consisting of all elements of this collection
    *         circularly rotated by `step` places to the left.
    * @example {{{
-   *      List(1, 2, 3, 4, 5).rotateLeft(1) => List(4, 5, 1, 2, 3)
+   *      List(1, 2, 3, 4, 5).rotateLeft(1) => List(2, 3, 4, 5, 1)
    * }}}
    */
   def rotateLeft[B >: seq.A, That](step: Int)(implicit bf: BuildFrom[C, B, That]): That =

--- a/src/main/scala/scala/collection/decorators/SeqDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/SeqDecorator.scala
@@ -81,11 +81,10 @@ class SeqDecorator[C, S <: IsSeq[C]](coll: C)(implicit val seq: S) {
    */
   def rotateRight[B >: seq.A, That](step: Int)(implicit bf: BuildFrom[C, B, That]): That =
     if (seq(coll).isEmpty)
-      bf.fromSpecific(coll)(new collection.View.Map(seq(coll), (a: seq.A) => a))
+      bf.fromSpecific(coll)(collection.View.Empty)
     else {
       val j: Index = seq(coll).size - index(step)
-      bf.fromSpecific(coll)(new collection.View.Drop(seq(coll), j) ++
-        new collection.View.Take(seq(coll), j))
+      bf.fromSpecific(coll)(new collection.View.Drop(seq(coll), j) ++ new collection.View.Take(seq(coll), j))
     }
 
   /** Considers the sequence circular and rotates it left by `step` places.

--- a/src/main/scala/scala/collection/decorators/SeqDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/SeqDecorator.scala
@@ -69,6 +69,18 @@ class SeqDecorator[C, S <: IsSeq[C]](coll: C)(implicit val seq: S) {
   private def index(i: IndexO): Index =
     java.lang.Math.floorMod(i, seq(coll).size)
 
+  /** Gets the element at some circular index.
+   *
+   * @param i circular index
+   * @return the element of the sequence at the given index
+   * @throws java.lang.ArithmeticException if the sequence is empty
+   * @example {{{
+   *      Seq(0, 1, 2).applyO(3) => 0
+   * }}}
+   */
+  def applyO(i: IndexO): this.seq.A =
+    seq(coll).apply(index(i))
+
   /** Considers the sequence circular and rotates it right by `step` places.
    *
    * @param step the number of places to be rotated to the right
@@ -99,18 +111,5 @@ class SeqDecorator[C, S <: IsSeq[C]](coll: C)(implicit val seq: S) {
    */
   def rotateLeft[B >: seq.A, That](step: Int)(implicit bf: BuildFrom[C, B, That]): That =
     rotateRight(-step)
-
-  /** Considers the sequence circular and rotates it to start with the element at `i` circular index.
-   *
-   * @param i the circular index of the element to be rotated at the start of the new collection
-   * @tparam B the element type of the returned collection
-   * @return a new collection consisting of all elements of this collection
-   *         circularly rotated so to start with the element at circular index `i`.
-   * @example {{{
-   *      List(1, 2, 3, 4, 5).startAt(2) => List(3, 4, 5, 1, 2)
-   * }}}
-   */
-  def startAt[B >: seq.A, That](i: IndexO)(implicit bf: BuildFrom[C, B, That]): That =
-    rotateLeft(i)
 
 }

--- a/src/main/scala/scala/collection/decorators/SeqDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/SeqDecorator.scala
@@ -55,4 +55,63 @@ class SeqDecorator[C, S <: IsSeq[C]](coll: C)(implicit val seq: S) {
     */
   def replaced[B >: seq.A, That](elem: B, replacement: B)(implicit bf: BuildFrom[C, B, That]): That =
     bf.fromSpecific(coll)(new collection.View.Map(seq(coll), (a: seq.A) => if (a == elem) replacement else a))
+
+  /**
+   * for improved readability, the integer index of an element in a Seq
+   */
+  type Index = Int
+
+  /**
+   * the integer index of an element in a circular Seq, any value is valid
+   */
+  type IndexO = Int
+
+  private def index(i: IndexO): Index =
+    java.lang.Math.floorMod(i, seq(coll).size)
+
+  /** Considers the sequence circular and rotates it right by `step` places.
+   *
+   * @param step the number of places to rotate to the right
+   * @tparam B the element type of the returned collection
+   * @return a new collection consisting of all elements of this collection
+   *         circularly rotated by `step` places to the right.
+   * @example {{{
+   *      List(1, 2, 3, 4).rotateRight(1) => List(2, 3, 4, 1)
+   * }}}
+   */
+  def rotateRight[B >: seq.A, That](step: Int)(implicit bf: BuildFrom[C, B, That]): That =
+    if (seq(coll).isEmpty)
+      bf.fromSpecific(coll)(new collection.View.Map(seq(coll), (a: seq.A) => a))
+    else {
+      val j: Index = seq(coll).size - index(step)
+      bf.fromSpecific(coll)(new collection.View.Drop(seq(coll), j) ++
+        new collection.View.Take(seq(coll), j))
+    }
+
+  /** Considers the sequence circular and rotates it left by `step` places.
+   *
+   * @param step the number of places to rotate to the left
+   * @tparam B the element type of the returned collection
+   * @return a new collection consisting of all elements of this collection
+   *         circularly rotated by `step` places to the left.
+   * @example {{{
+   *      List(1, 2, 3, 4).rotateLeft(1) => List(4, 1, 2, 3)
+   * }}}
+   */
+  def rotateLeft[B >: seq.A, That](step: Int)(implicit bf: BuildFrom[C, B, That]): That =
+    rotateRight(-step)
+
+  /** Considers the sequence circular and move its head to the `i` circular index.
+   *
+   * @param i the circular index of the element at the start of the new collection
+   * @tparam B the element type of the returned collection
+   * @return a new collection consisting of all elements of this collection
+   *         circularly rotated so that the head element is at circular index `i`.
+   * @example {{{
+   *      List(1, 2, 3, 4).startAt(-1) => List(2, 3, 4, 1)
+   * }}}
+   */
+  def startAt[B >: seq.A, That](i: IndexO)(implicit bf: BuildFrom[C, B, That]): That =
+    rotateLeft(i)
+
 }

--- a/src/main/scala/scala/collection/decorators/SeqDecorator.scala
+++ b/src/main/scala/scala/collection/decorators/SeqDecorator.scala
@@ -71,12 +71,12 @@ class SeqDecorator[C, S <: IsSeq[C]](coll: C)(implicit val seq: S) {
 
   /** Considers the sequence circular and rotates it right by `step` places.
    *
-   * @param step the number of places to rotate to the right
+   * @param step the number of places to be rotated to the right
    * @tparam B the element type of the returned collection
    * @return a new collection consisting of all elements of this collection
    *         circularly rotated by `step` places to the right.
    * @example {{{
-   *      List(1, 2, 3, 4).rotateRight(1) => List(2, 3, 4, 1)
+   *      List(1, 2, 3, 4, 5).rotateRight(1) => List(2, 3, 4, 5, 1)
    * }}}
    */
   def rotateRight[B >: seq.A, That](step: Int)(implicit bf: BuildFrom[C, B, That]): That =
@@ -90,25 +90,25 @@ class SeqDecorator[C, S <: IsSeq[C]](coll: C)(implicit val seq: S) {
 
   /** Considers the sequence circular and rotates it left by `step` places.
    *
-   * @param step the number of places to rotate to the left
+   * @param step the number of places to be rotated to the left
    * @tparam B the element type of the returned collection
    * @return a new collection consisting of all elements of this collection
    *         circularly rotated by `step` places to the left.
    * @example {{{
-   *      List(1, 2, 3, 4).rotateLeft(1) => List(4, 1, 2, 3)
+   *      List(1, 2, 3, 4, 5).rotateLeft(1) => List(4, 5, 1, 2, 3)
    * }}}
    */
   def rotateLeft[B >: seq.A, That](step: Int)(implicit bf: BuildFrom[C, B, That]): That =
     rotateRight(-step)
 
-  /** Considers the sequence circular and move its head to the `i` circular index.
+  /** Considers the sequence circular and rotates it to start with the element at `i` circular index.
    *
-   * @param i the circular index of the element at the start of the new collection
+   * @param i the circular index of the element to be rotated at the start of the new collection
    * @tparam B the element type of the returned collection
    * @return a new collection consisting of all elements of this collection
-   *         circularly rotated so that the head element is at circular index `i`.
+   *         circularly rotated so to start with the element at circular index `i`.
    * @example {{{
-   *      List(1, 2, 3, 4).startAt(-1) => List(2, 3, 4, 1)
+   *      List(1, 2, 3, 4, 5).startAt(2) => List(3, 4, 5, 1, 2)
    * }}}
    */
   def startAt[B >: seq.A, That](i: IndexO)(implicit bf: BuildFrom[C, B, That]): That =

--- a/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
@@ -51,6 +51,7 @@ class SeqDecoratorTest {
     val string = "RING"
     assertEquals(s.rotateRight(1), Seq(1, 1, 2, 3, 2))
     assertEquals(string.rotateRight(1).mkString, "GRIN")
+    assertEquals(Vector.empty.rotateRight(1), Vector.empty)
   }
 
   @Test def testRotatedLeft(): Unit = {

--- a/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
@@ -53,7 +53,7 @@ class SeqDecoratorTest {
     assertEquals(s.rotateRight(6), sRotated)
     assertEquals(s.rotateRight(-4), sRotated)
     val string = "RING"
-    assertEquals(string.rotateRight(1).mkString, "GRIN")
+    assertEquals(string.rotateRight(1), "GRIN")
     val empty = Vector.empty[Int]
     assertEquals(empty.rotateRight(1), empty)
   }

--- a/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 package decorators
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertSame, assertThrows}
 import org.junit.Test
 import scala.collection.immutable._
 
@@ -46,6 +46,13 @@ class SeqDecoratorTest {
     assertEquals(s.replaced(4, 4), s)
   }
 
+  @Test def testApplyO(): Unit = {
+    val s = Seq(0, 1, 2)
+    assertEquals(s.applyO(3), 0)
+    val empty = Vector.empty[Int]
+    assertThrows(classOf[java.lang.ArithmeticException], () => empty.applyO(1))
+  }
+
   @Test def testRotatedRight(): Unit = {
     val s = Seq(1, 2, 3, 2, 1)
     val sRotated = Seq(1, 1, 2, 3, 2)
@@ -64,14 +71,6 @@ class SeqDecoratorTest {
     assertEquals(s.rotateLeft(1), sRotated)
     assertEquals(s.rotateLeft(6), sRotated)
     assertEquals(s.rotateLeft(-4), sRotated)
-  }
-
-  @Test def testStartedAt(): Unit = {
-    val s = Seq(1, 2, 3, 2, 1)
-    val sRotated = Seq(2, 3, 2, 1, 1)
-    assertEquals(s.startAt(1), sRotated)
-    assertEquals(s.startAt(6), sRotated)
-    assertEquals(s.startAt(-4), sRotated)
   }
 
 }

--- a/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
@@ -45,4 +45,22 @@ class SeqDecoratorTest {
     assertEquals(s.replaced(3, 4), Seq(1, 2, 4, 2, 1))
     assertEquals(s.replaced(4, 4), s)
   }
+
+  @Test def testRotatedRight(): Unit = {
+    val s = Seq(1, 2, 3, 2, 1)
+    val string = "RING"
+    assertEquals(s.rotateRight(1), Seq(1, 1, 2, 3, 2))
+    assertEquals(string.rotateRight(1).mkString, "GRIN")
+  }
+
+  @Test def testRotatedLeft(): Unit = {
+    val s = Seq(1, 2, 3, 2, 1)
+    assertEquals(s.rotateLeft(1), Seq(2, 3, 2, 1, 1))
+  }
+
+  @Test def testStartedAt(): Unit = {
+    val s = Seq(1, 2, 3, 2, 1)
+    assertEquals(s.startAt(1), Seq(2, 3, 2, 1, 1))
+  }
+
 }

--- a/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
@@ -48,21 +48,30 @@ class SeqDecoratorTest {
 
   @Test def testRotatedRight(): Unit = {
     val s = Seq(1, 2, 3, 2, 1)
+    val sRotated = Seq(1, 1, 2, 3, 2)
+    assertEquals(s.rotateRight(1), sRotated)
+    assertEquals(s.rotateRight(6), sRotated)
+    assertEquals(s.rotateRight(-4), sRotated)
     val string = "RING"
-    val empty = Vector.empty[Int]
-    assertEquals(s.rotateRight(1), Seq(1, 1, 2, 3, 2))
     assertEquals(string.rotateRight(1).mkString, "GRIN")
+    val empty = Vector.empty[Int]
     assertEquals(empty.rotateRight(1), empty)
   }
 
   @Test def testRotatedLeft(): Unit = {
     val s = Seq(1, 2, 3, 2, 1)
-    assertEquals(s.rotateLeft(1), Seq(2, 3, 2, 1, 1))
+    val sRotated = Seq(2, 3, 2, 1, 1)
+    assertEquals(s.rotateLeft(1), sRotated)
+    assertEquals(s.rotateLeft(6), sRotated)
+    assertEquals(s.rotateLeft(-4), sRotated)
   }
 
   @Test def testStartedAt(): Unit = {
     val s = Seq(1, 2, 3, 2, 1)
-    assertEquals(s.startAt(1), Seq(2, 3, 2, 1, 1))
+    val sRotated = Seq(2, 3, 2, 1, 1)
+    assertEquals(s.startAt(1), sRotated)
+    assertEquals(s.startAt(6), sRotated)
+    assertEquals(s.startAt(-4), sRotated)
   }
 
 }

--- a/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
@@ -49,9 +49,10 @@ class SeqDecoratorTest {
   @Test def testRotatedRight(): Unit = {
     val s = Seq(1, 2, 3, 2, 1)
     val string = "RING"
+    val empty = Vector()
     assertEquals(s.rotateRight(1), Seq(1, 1, 2, 3, 2))
     assertEquals(string.rotateRight(1).mkString, "GRIN")
-    assertEquals(Vector.empty.rotateRight(1), Vector.empty)
+    assertEquals(empty.rotateRight(1), empty)
   }
 
   @Test def testRotatedLeft(): Unit = {

--- a/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
+++ b/src/test/scala/scala/collection/decorators/SeqDecoratorTest.scala
@@ -49,7 +49,7 @@ class SeqDecoratorTest {
   @Test def testRotatedRight(): Unit = {
     val s = Seq(1, 2, 3, 2, 1)
     val string = "RING"
-    val empty = Vector()
+    val empty = Vector.empty[Int]
     assertEquals(s.rotateRight(1), Seq(1, 1, 2, 3, 2))
     assertEquals(string.rotateRight(1).mkString, "GRIN")
     assertEquals(empty.rotateRight(1), empty)


### PR DESCRIPTION
I would like to add to `Seq` several operations, all related to considering a `Seq` (or a subtype) a circular sequence.

If you take a look at my library repo at https://github.com/scala-tessella/ring-seq, these are all the methods that I have in mind.

But I started here adding just three, since I need to get used to the intricacies of the Scala collections.

If this is of interest, I will have many more questions on how to correctly add other methods.

