### PR TITLE
adapt to change in Scala 2.13.9 + Scala 3.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-ThisBuild / scalaVersion := "3.1.3"
-ThisBuild / crossScalaVersions := Seq((ThisBuild / scalaVersion).value, "2.13.8")
+ThisBuild / scalaVersion := "3.2.1"
+ThisBuild / crossScalaVersions := Seq((ThisBuild / scalaVersion).value, "2.13.10")
 
 lazy val root = project.in(file("."))
   .aggregate(collectionContrib.jvm, collectionContrib.js, collectionContrib.native)

--- a/src/main/scala/scala/collection/MultiDict.scala
+++ b/src/main/scala/scala/collection/MultiDict.scala
@@ -198,7 +198,7 @@ trait MultiDictOps[K, V, +CC[X, Y] <: MultiDict[X, Y], +C <: MultiDict[K, V]]
   def filterSets(p: ((K, Set[V])) => Boolean): C =
     fromSpecificSets(new View.Filter(sets, p, isFlipped = false))
 
-  override def addString(sb: StringBuilder, start: String, sep: String, end: String): StringBuilder =
+  override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type =
     iterator.map { case (k, v) => s"$k -> $v" }.addString(sb, start, sep, end)
 }
 


### PR DESCRIPTION
namely https://github.com/scala/scala/pull/10047

this came up at https://github.com/scala/community-build/pull/1579

not for merge until 2.13.9 is actually released and we can upgrade, so that compilation will succeed

in the meantime we can use the branch in the community build