### PR TITLE
Scala Native Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,10 @@ lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     Test / fork := false
   )
   .nativeEnablePlugins(ScalaNativeJUnitPlugin)
+  .nativeSettings(
+    // Scala native cannot run forked tests
+    Test / fork := false
+  )
 
 lazy val collectionContribJVM    = collectionContrib.jvm
 lazy val collectionContribJS     = collectionContrib.js

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     Compile / compile / scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) => Seq("-opt-warnings", "-Werror", "-Wconf:origin=scala.collection.IterableOps.toIterable:s")
-        case _            => Seq("-Xfatal-warnings", /*"-scala-output-version:3.0",*/ "-Wconf:cat=deprecation:s")
+        case _            => Seq("-Xfatal-warnings", "-Wconf:cat=deprecation:s")
       }
     },
     Compile / doc / scalacOptions ++= {
@@ -43,9 +43,6 @@ lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     Test / fork := false
   )
   .nativeEnablePlugins(ScalaNativeJUnitPlugin)
-  .nativeSettings(
-    Test / fork := false // is this needed?
-  )
 
 lazy val collectionContribJVM    = collectionContrib.jvm
 lazy val collectionContribJS     = collectionContrib.js

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / scalaVersion := "3.1.3"
 ThisBuild / crossScalaVersions := Seq((ThisBuild / scalaVersion).value, "2.13.8")
 
 lazy val root = project.in(file("."))
-  .aggregate(collectionContrib.jvm, collectionContrib.js)
+  .aggregate(collectionContrib.jvm, collectionContrib.js, collectionContrib.native)
   .settings(
     publish / skip := true,
     // With CrossType.Pure, the root project also picks up the sources in `src`
@@ -10,7 +10,7 @@ lazy val root = project.in(file("."))
     Test    / unmanagedSourceDirectories := Nil,
   )
 
-lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform)
+lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("."))
   .settings(ScalaModulePlugin.scalaModuleSettings)
@@ -21,7 +21,7 @@ lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform)
     Compile / compile / scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) => Seq("-opt-warnings", "-Werror", "-Wconf:origin=scala.collection.IterableOps.toIterable:s")
-        case _            => Seq("-Xfatal-warnings", "-scala-output-version:3.0", "-Wconf:cat=deprecation:s")
+        case _            => Seq("-Xfatal-warnings", /*"-scala-output-version:3.0",*/ "-Wconf:cat=deprecation:s")
       }
     },
     Compile / doc / scalacOptions ++= {
@@ -42,6 +42,11 @@ lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform)
     // Scala.js cannot run forked tests
     Test / fork := false
   )
+  .nativeEnablePlugins(ScalaNativeJUnitPlugin)
+  .nativeSettings(
+    Test / fork := false // is this needed?
+  )
 
-lazy val collectionContribJVM = collectionContrib.jvm
-lazy val collectionContribJS  = collectionContrib.js
+lazy val collectionContribJVM    = collectionContrib.jvm
+lazy val collectionContribJS     = collectionContrib.js
+lazy val collectionContribNative = collectionContrib.native

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "3.0.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.7")


### PR DESCRIPTION
Added Scala native support fixing #187, but this required, for some reason, removing the `-scala-output-version:3.0` flag for Scala 3 compilation. With that flag on, there are two errors;

```
[error] The class scala.scalanative.unsafe.package cannot be loaded from file scala/scalanative/unsafe/package.tasty because its TASTy format is not compatible with the one of the targeted Scala release (3.0):
[error] highest allowed: 28.0-0
[error] found:           28.1-0
[error]               
[error] The class scala.scalanative.unsafe.UnsafePackageCompat cannot be loaded from file scala/scalanative/unsafe/UnsafePackageCompat.tasty because its TASTy format is not compatible with the one of the targeted Scala release (3.0):
[error] highest allowed: 28.0-0
[error] found:           28.1-0
[error]               
[error] two errors found
```