### PR TITLE
add onEmpty chaining method on Option

### DIFF
--- a/src/main/scala/scala/decorators/OptionDecorator.scala
+++ b/src/main/scala/scala/decorators/OptionDecorator.scala
@@ -1,0 +1,23 @@
+package scala.decorators
+
+class OptionDecorator[A](private val opt: Option[A]) extends AnyVal {
+  /** Evaluates the argument if the option is empty and returns the option unmodified
+    *
+    * This is useful to perform an operation for its side-effect, while still allowing chaining,
+    * much like [[Option#tapEach]] does, but for when the option empty rather than defined
+    * @example {{{
+    *   def maybeAdd(firstOption: Option[Int], secondOption: Option[Int]) = 
+    *     for {
+    *       first <- firstOption.onEmpty(println("first was empty"))
+    *       second <- secondOption.onEmpty(println("second was empty"))
+    *     }   yield first + second
+    * }}}
+    * @tparam U a dummy type, that allows you to pass in any block, regardless of its type
+    * @param f the code to evaluate when the option is empty
+    * @return the source option unmodified
+    */
+  def onEmpty[U](f: => U): Option[A] = {
+    if (opt.isEmpty) f
+    opt
+  }
+}

--- a/src/main/scala/scala/decorators/package.scala
+++ b/src/main/scala/scala/decorators/package.scala
@@ -1,0 +1,8 @@
+package scala
+
+import scala.language.implicitConversions
+
+package object decorators {
+  implicit def optionDecorator[A](opt: Option[A]): OptionDecorator[A] = new OptionDecorator(opt) 
+  
+}

--- a/src/test/scala/scala/decorators/OptionDecoratorTest.scala
+++ b/src/test/scala/scala/decorators/OptionDecoratorTest.scala
@@ -1,0 +1,23 @@
+package scala
+package decorators
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import scala.collection.immutable._
+
+class OptionDecoratorTest {
+
+  @Test def onEmptyNone(): Unit = {
+    var isSet = false
+    def set: Unit = isSet = true
+    None.onEmpty(set)
+    assertEquals(true, isSet)
+  }
+
+  @Test def onEmptySome(): Unit = {
+    var isSet = false
+    def set: Unit = isSet = true
+    Some("potato").onEmpty(set)
+    assertEquals(false, isSet)
+  }
+}


### PR DESCRIPTION
I think this feature is worthwhile to have. There is some room for debate here: should the parameter be a by-name, or should it be a Function0? without Function0, you can do 

```scala
None.onEmpty {
  do
  something
}
```

which is nice, but at the same time, it feels a bit dangerous.

There is also the matter of namespacing. I've added a new `scala.decorators`, because it doesn't feel very right on `scala.collection.decorators`, but adding a required import to `scala.decorators._` might add to confusion.

Lastly, this may also be nice to have on `Iterable`.

What do you all think? And an option is like a collection with one element, so it belongs in the repo, right?