### PR TITLE
Remove junit -q parameter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val collectionContrib = crossProject(JVMPlatform, JSPlatform, NativePlatfor
         case _            => Seq.empty
       }
     },
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a"),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-s", "-a"),
     Test / parallelExecution := false,  // why?
     libraryDependencies ++= Seq(
       "junit"            % "junit"           % "4.13.2" % Test,


### PR DESCRIPTION
Applying this PR will remove the `-q` parameter from the junit tests, as this is no longer supported in newer versions of Scala Native: https://github.com/scala-native/scala-native/pull/3425.